### PR TITLE
Add default config and builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# JSON Generator
+
 A JSON data generator from JSON Schemas, provided as a Java library.
 
 It is available on JitPack.
@@ -5,4 +7,42 @@ It is available on JitPack.
 
 An online demonstration [is here](https://tryjsonschematypes.appspot.com/#generate).
 
+## How to Use
+
+```java
+import java.util.Random;
+import net.jimblackler.jsonschemafriend.Schema;
+import net.jimblackler.jsonschemafriend.SchemaStore;
+
+public class JsonGenerationExample {
+
+  /**
+   * Generate random Json with the following schema:
+   * {
+   *   "type": "object",
+   *   "properties": {
+   *     "name": { "type": "string" },
+   *     "birthday": { "type": "string","format": "date" },
+   *     "age": { "type": "integer" }
+   *   }
+   * }
+   */
+  public static void main(String[] args) throws Exception {
+    Configuration config = DefaultConfig.build()
+        .setGenerateMinimal(false)
+        .setNonRequiredPropertyChance(0.5f)
+        .get();
+    SchemaStore schemaStore = new SchemaStore(true);
+    Schema schema = schemaStore.loadSchemaJson("{ \"type\": \"object\", \"properties\": { \"name\": { \"type\": \"string\" }, \"birthday\": { \"type\": \"string\", \"format\": \"date\" }, \"age\": { \"type\": \"integer\" } } }");
+    Generator generator = new Generator(config, schemaStore, new Random());
+    Object json = generator.generate(schema, 10);
+
+    // sample output: {name=vxtydd, birthday=2377-03-08, age=544}
+    System.out.println(json);
+  }
+
+}
+```
+
+## License
 Written by jimblackler@gmail.com and offered under an Apache 2.0 license.

--- a/src/main/java/net/jimblackler/jsongenerator/DefaultConfig.java
+++ b/src/main/java/net/jimblackler/jsongenerator/DefaultConfig.java
@@ -1,0 +1,113 @@
+package net.jimblackler.jsongenerator;
+
+public class DefaultConfig implements Configuration {
+
+  private final boolean pedanticTypes;
+  private final boolean generateNulls;
+  private final boolean generateMinimal;
+  private final boolean generateAdditionalProperties;
+  private final boolean useRomanCharsOnly;
+  private final float nonRequiredPropertyChance;
+
+  private DefaultConfig(boolean pedanticTypes,
+                        boolean generateNulls,
+                        boolean generateMinimal,
+                        boolean generateAdditionalProperties,
+                        boolean useRomanCharsOnly,
+                        float nonRequiredPropertyChance) {
+    this.pedanticTypes = pedanticTypes;
+    this.generateNulls = generateNulls;
+    this.generateMinimal = generateMinimal;
+    this.generateAdditionalProperties = generateAdditionalProperties;
+    this.useRomanCharsOnly = useRomanCharsOnly;
+    this.nonRequiredPropertyChance = nonRequiredPropertyChance;
+  }
+
+  public static Builder build() {
+    return new Builder();
+  }
+
+  @Override
+  public boolean isPedanticTypes() {
+    return pedanticTypes;
+  }
+
+  @Override
+  public boolean isGenerateNulls() {
+    return generateNulls;
+  }
+
+  @Override
+  public boolean isGenerateMinimal() {
+    return generateMinimal;
+  }
+
+  @Override
+  public boolean isGenerateAdditionalProperties() {
+    return generateAdditionalProperties;
+  }
+
+  @Override
+  public boolean useRomanCharsOnly() {
+    return useRomanCharsOnly;
+  }
+
+  @Override
+  public float nonRequiredPropertyChance() {
+    return nonRequiredPropertyChance;
+  }
+
+  public static class Builder {
+
+    private boolean pedanticTypes = true;
+    private boolean generateNulls = false;
+    private boolean generateMinimal = false;
+    private boolean generateAdditionalProperties = false;
+    private boolean useRomanCharsOnly = true;
+    private float nonRequiredPropertyChance = 1.0f;
+
+    private Builder() {
+    }
+
+    public Builder setPedanticTypes(boolean pedanticTypes) {
+      this.pedanticTypes = pedanticTypes;
+      return this;
+    }
+
+    public Builder setGenerateNulls(boolean generateNulls) {
+      this.generateNulls = generateNulls;
+      return this;
+    }
+
+    public Builder setGenerateMinimal(boolean generateMinimal) {
+      this.generateMinimal = generateMinimal;
+      return this;
+    }
+
+    public Builder setGenerateAdditionalProperties(boolean generateAdditionalProperties) {
+      this.generateAdditionalProperties = generateAdditionalProperties;
+      return this;
+    }
+
+    public Builder setUseRomanCharsOnly(boolean useRomanCharsOnly) {
+      this.useRomanCharsOnly = useRomanCharsOnly;
+      return this;
+    }
+
+    public Builder setNonRequiredPropertyChance(float nonRequiredPropertyChance) {
+      this.nonRequiredPropertyChance = nonRequiredPropertyChance;
+      return this;
+    }
+
+    public DefaultConfig get() {
+      return new DefaultConfig(
+          pedanticTypes,
+          generateNulls,
+          generateMinimal,
+          generateAdditionalProperties,
+          useRomanCharsOnly,
+          nonRequiredPropertyChance);
+    }
+  }
+
+}

--- a/src/main/java/net/jimblackler/jsongenerator/DefaultConfig.java
+++ b/src/main/java/net/jimblackler/jsongenerator/DefaultConfig.java
@@ -9,12 +9,12 @@ public class DefaultConfig implements Configuration {
   private final boolean useRomanCharsOnly;
   private final float nonRequiredPropertyChance;
 
-  private DefaultConfig(boolean pedanticTypes,
-                        boolean generateNulls,
-                        boolean generateMinimal,
-                        boolean generateAdditionalProperties,
-                        boolean useRomanCharsOnly,
-                        float nonRequiredPropertyChance) {
+  public DefaultConfig(boolean pedanticTypes,
+                       boolean generateNulls,
+                       boolean generateMinimal,
+                       boolean generateAdditionalProperties,
+                       boolean useRomanCharsOnly,
+                       float nonRequiredPropertyChance) {
     this.pedanticTypes = pedanticTypes;
     this.generateNulls = generateNulls;
     this.generateMinimal = generateMinimal;

--- a/src/test/java/net/jimblackler/jsongenerator/FakeSchemaTest.java
+++ b/src/test/java/net/jimblackler/jsongenerator/FakeSchemaTest.java
@@ -51,6 +51,16 @@ public class FakeSchemaTest {
           }
 
           @Override
+          public boolean isGenerateAdditionalProperties() {
+            return false;
+          }
+
+          @Override
+          public boolean useRomanCharsOnly() {
+            return false;
+          }
+
+          @Override
           public float nonRequiredPropertyChance() {
             return 0.5f;
           }

--- a/src/test/java/net/jimblackler/jsongenerator/FakeSchemaTest.java
+++ b/src/test/java/net/jimblackler/jsongenerator/FakeSchemaTest.java
@@ -34,37 +34,15 @@ public class FakeSchemaTest {
       testsOut.add(dynamicTest("" + attempt, () -> {
         SchemaStore schemaStore = new SchemaStore();
 
-        Generator generator = new Generator(new Configuration() {
-          @Override
-          public boolean isPedanticTypes() {
-            return false;
-          }
-
-          @Override
-          public boolean isGenerateNulls() {
-            return false;
-          }
-
-          @Override
-          public boolean isGenerateMinimal() {
-            return false;
-          }
-
-          @Override
-          public boolean isGenerateAdditionalProperties() {
-            return false;
-          }
-
-          @Override
-          public boolean useRomanCharsOnly() {
-            return false;
-          }
-
-          @Override
-          public float nonRequiredPropertyChance() {
-            return 0.5f;
-          }
-        }, schemaStore, new Random(finalAttempt));
+        Configuration config = DefaultConfig.build()
+            .setPedanticTypes(false)
+            .setGenerateNulls(false)
+            .setGenerateMinimal(false)
+            .setGenerateAdditionalProperties(false)
+            .setUseRomanCharsOnly(false)
+            .setNonRequiredPropertyChance(0.5f)
+            .get();
+        Generator generator = new Generator(config, schemaStore, new Random(finalAttempt));
         Object generated = generator.generate(schema, 16);
 
         System.out.println(objectWriter.writeValueAsString(generated));

--- a/src/test/java/net/jimblackler/jsongenerator/FromInternet.java
+++ b/src/test/java/net/jimblackler/jsongenerator/FromInternet.java
@@ -61,6 +61,16 @@ public class FromInternet {
             }
 
             @Override
+            public boolean isGenerateAdditionalProperties() {
+              return false;
+            }
+
+            @Override
+            public boolean useRomanCharsOnly() {
+              return false;
+            }
+
+            @Override
             public float nonRequiredPropertyChance() {
               return 0.5f;
             }

--- a/src/test/java/net/jimblackler/jsongenerator/FromInternet.java
+++ b/src/test/java/net/jimblackler/jsongenerator/FromInternet.java
@@ -44,37 +44,15 @@ public class FromInternet {
           System.out.println(objectWriter.writeValueAsString(schema.getSchemaObject()));
           System.out.println();
 
-          Object object = new Generator(new Configuration() {
-            @Override
-            public boolean isPedanticTypes() {
-              return false;
-            }
-
-            @Override
-            public boolean isGenerateNulls() {
-              return false;
-            }
-
-            @Override
-            public boolean isGenerateMinimal() {
-              return false;
-            }
-
-            @Override
-            public boolean isGenerateAdditionalProperties() {
-              return false;
-            }
-
-            @Override
-            public boolean useRomanCharsOnly() {
-              return false;
-            }
-
-            @Override
-            public float nonRequiredPropertyChance() {
-              return 0.5f;
-            }
-          }, schemaStore, new Random(1)).generate(schema, 20);
+          Configuration config = DefaultConfig.build()
+              .setPedanticTypes(false)
+              .setGenerateNulls(false)
+              .setGenerateMinimal(false)
+              .setGenerateAdditionalProperties(false)
+              .setUseRomanCharsOnly(false)
+              .setNonRequiredPropertyChance(0.5f)
+              .get();
+          Object object = new Generator(config, schemaStore, new Random(1)).generate(schema, 20);
           System.out.println("Data:");
           System.out.println(objectWriter.writeValueAsString(object));
           System.out.println();

--- a/src/test/java/net/jimblackler/jsongenerator/SchemaStoreTest.java
+++ b/src/test/java/net/jimblackler/jsongenerator/SchemaStoreTest.java
@@ -65,6 +65,16 @@ public class SchemaStoreTest {
             }
 
             @Override
+            public boolean isGenerateAdditionalProperties() {
+              return false;
+            }
+
+            @Override
+            public boolean useRomanCharsOnly() {
+              return false;
+            }
+
+            @Override
             public float nonRequiredPropertyChance() {
               return 0.5f;
             }

--- a/src/test/java/net/jimblackler/jsongenerator/SchemaStoreTest.java
+++ b/src/test/java/net/jimblackler/jsongenerator/SchemaStoreTest.java
@@ -48,37 +48,15 @@ public class SchemaStoreTest {
           System.out.println("Schema:");
           System.out.println(objectWriter.writeValueAsString(schema.getSchemaObject()));
           System.out.println();
-          Object generated = new Generator(new Configuration() {
-            @Override
-            public boolean isPedanticTypes() {
-              return false;
-            }
-
-            @Override
-            public boolean isGenerateNulls() {
-              return false;
-            }
-
-            @Override
-            public boolean isGenerateMinimal() {
-              return false;
-            }
-
-            @Override
-            public boolean isGenerateAdditionalProperties() {
-              return false;
-            }
-
-            @Override
-            public boolean useRomanCharsOnly() {
-              return false;
-            }
-
-            @Override
-            public float nonRequiredPropertyChance() {
-              return 0.5f;
-            }
-          }, schemaStore, new Random(1)).generate(schema, 16);
+          Configuration config = DefaultConfig.build()
+              .setPedanticTypes(false)
+              .setGenerateNulls(false)
+              .setGenerateMinimal(false)
+              .setGenerateAdditionalProperties(false)
+              .setUseRomanCharsOnly(false)
+              .setNonRequiredPropertyChance(0.5f)
+              .get();
+          Object generated = new Generator(config, schemaStore, new Random(1)).generate(schema, 16);
 
           System.out.println(objectWriter.writeValueAsString(generated));
           new Validator().validate(schema, generated);

--- a/src/test/java/net/jimblackler/jsongenerator/SuiteTest.java
+++ b/src/test/java/net/jimblackler/jsongenerator/SuiteTest.java
@@ -100,6 +100,16 @@ public class SuiteTest {
                       }
 
                       @Override
+                      public boolean isGenerateAdditionalProperties() {
+                        return false;
+                      }
+
+                      @Override
+                      public boolean useRomanCharsOnly() {
+                        return false;
+                      }
+
+                      @Override
                       public float nonRequiredPropertyChance() {
                         return 0.5f;
                       }

--- a/src/test/java/net/jimblackler/jsongenerator/SuiteTest.java
+++ b/src/test/java/net/jimblackler/jsongenerator/SuiteTest.java
@@ -83,37 +83,15 @@ public class SuiteTest {
                     net.jimblackler.jsonschemafriend.Schema schema1 =
                         schemaStore.loadSchema(schema);
 
-                    Object generated = new Generator(new Configuration() {
-                      @Override
-                      public boolean isPedanticTypes() {
-                        return false;
-                      }
-
-                      @Override
-                      public boolean isGenerateNulls() {
-                        return false;
-                      }
-
-                      @Override
-                      public boolean isGenerateMinimal() {
-                        return false;
-                      }
-
-                      @Override
-                      public boolean isGenerateAdditionalProperties() {
-                        return false;
-                      }
-
-                      @Override
-                      public boolean useRomanCharsOnly() {
-                        return false;
-                      }
-
-                      @Override
-                      public float nonRequiredPropertyChance() {
-                        return 0.5f;
-                      }
-                    }, schemaStore, new Random(1)).generate(schema1, 16);
+                    Configuration config = DefaultConfig.build()
+                        .setPedanticTypes(false)
+                        .setGenerateNulls(false)
+                        .setGenerateMinimal(false)
+                        .setGenerateAdditionalProperties(false)
+                        .setUseRomanCharsOnly(false)
+                        .setNonRequiredPropertyChance(0.5f)
+                        .get();
+                    Object generated = new Generator(config, schemaStore, new Random(1)).generate(schema1, 16);
 
                     System.out.println(objectWriter.writeValueAsString(generated));
                     new Validator().validate(schema1, generated);

--- a/src/test/java/net/jimblackler/jsongenerator/Test.java
+++ b/src/test/java/net/jimblackler/jsongenerator/Test.java
@@ -48,6 +48,16 @@ public class Test {
       }
 
       @Override
+      public boolean isGenerateAdditionalProperties() {
+        return false;
+      }
+
+      @Override
+      public boolean useRomanCharsOnly() {
+        return false;
+      }
+
+      @Override
       public float nonRequiredPropertyChance() {
         return 0.5f;
       }

--- a/src/test/java/net/jimblackler/jsongenerator/Test.java
+++ b/src/test/java/net/jimblackler/jsongenerator/Test.java
@@ -31,37 +31,15 @@ public class Test {
     SchemaStore schemaStore = new SchemaStore();
     Schema schema = schemaStore.loadSchema(Test.class.getResource(file.toString()).toURI());
 
-    Object object = new Generator(new Configuration() {
-      @Override
-      public boolean isPedanticTypes() {
-        return false;
-      }
-
-      @Override
-      public boolean isGenerateNulls() {
-        return false;
-      }
-
-      @Override
-      public boolean isGenerateMinimal() {
-        return true;
-      }
-
-      @Override
-      public boolean isGenerateAdditionalProperties() {
-        return false;
-      }
-
-      @Override
-      public boolean useRomanCharsOnly() {
-        return false;
-      }
-
-      @Override
-      public float nonRequiredPropertyChance() {
-        return 0.5f;
-      }
-    }, schemaStore, new Random(1)).generate(schema, 16);
+    Configuration config = DefaultConfig.build()
+        .setPedanticTypes(false)
+        .setGenerateNulls(false)
+        .setGenerateMinimal(true)
+        .setGenerateAdditionalProperties(false)
+        .setUseRomanCharsOnly(false)
+        .setNonRequiredPropertyChance(0.5f)
+        .get();
+    Object object = new Generator(config, schemaStore, new Random(1)).generate(schema, 16);
 
     new Validator().validate(schema, object);
     try (BufferedWriter writer = new BufferedWriter(new FileWriter(out.toFile()))) {


### PR DESCRIPTION
@jimblackler, thank you for creating this library. This is probably the only open source random Json object generator available in Java.

## Description
Currently the `Configuration` is just an interface, and each time the user needs to implement it. One downside of this approach is that whenever there are new options added to the configuration, all the implementations will be updated. The example is that many of the test files cannot compile, because their implementation of the `Configuration` lacks the two newly added options from https://github.com/jimblackler/jsongenerator/pull/3.

## Implementation
The solution proposed in this PR is to
- Add a default implementation of this interface.
- Add a builder with default values of all the options.

There are two ways to create a `DefaultConfig`, both of them are much more concise:

```java
Configuration config = new DefaultConfig(false, false, false, true, false, 0.5f);
```

or

```java
Configuration config = DefaultConfig.build()
    .setGenerateMinimal(false)
    .setNonRequiredPropertyChance(0.5f)
    .get();
```

The builder approach is recommended because new options won't affect existing use cases.

Also I add an example of how to use this library in the README.
