### PR TITLE
Remove print statements

### DIFF
--- a/src/main/java/net/jimblackler/jsongenerator/Fixer.java
+++ b/src/main/java/net/jimblackler/jsongenerator/Fixer.java
@@ -46,7 +46,6 @@ import net.jimblackler.jsonschemafriend.Validator;
 public class Fixer {
   static Object fixUp(Schema schema, Object object, Generator generator, Random random,
       PatternReverser patternReverser, boolean useRomanCharsOnly) throws JsonGeneratorException {
-    int attempt = 0;
     Set<String> considered = new HashSet<>();
     while (true) {
       Collection<ValidationError> errors = new ArrayList<>();
@@ -55,14 +54,6 @@ public class Fixer {
       if (errors.isEmpty()) {
         break;
       }
-
-      attempt++;
-
-      System.out.println("Attempt " + attempt + ":");
-      for (ValidationError error : errors) {
-        System.out.println(error);
-      }
-      System.out.println();
 
       if (!considered.add(object.toString())) {
         break;


### PR DESCRIPTION
## Summary
I'd like to propose to remove these print statements. We use this library for benchmark tests in production. These print statements can generate a lot of noises in the logs. There can be multiple printouts for each generated Json object, if not lucky.
