### PR TITLE
Introduce formatted string generators

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,12 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.5'
     implementation 'cat.inspiracio:rhino-js-engine:1.7.10'
     implementation 'net.jimblackler.jsonschemafriend:core:0.11.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.0'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 task sourceJar(type: Jar) {

--- a/src/main/java/net/jimblackler/jsongenerator/Generator.java
+++ b/src/main/java/net/jimblackler/jsongenerator/Generator.java
@@ -17,7 +17,9 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
+import net.jimblackler.jsongenerator.format.FormattedStringGenerators;
 import net.jimblackler.jsonschemafriend.CombinedSchema;
 import net.jimblackler.jsonschemafriend.GenerationException;
 import net.jimblackler.jsonschemafriend.Schema;
@@ -57,17 +59,19 @@ public class Generator {
   private final Random random;
   private final PatternReverser patternReverser;
   private final Schema anySchema;
+  private final FormattedStringGenerators generators;
 
   public Generator(Configuration configuration, SchemaStore schemaStore, Random random)
       throws GenerationException {
     this.configuration = configuration;
     this.random = random;
-    anySchema = schemaStore.loadSchema(true);
+    this.anySchema = schemaStore.loadSchema(true);
     try {
-      patternReverser = new PatternReverser();
+      this.patternReverser = new PatternReverser();
     } catch (IOException e) {
       throw new GenerationException(e);
     }
+    this.generators = new FormattedStringGenerators();
   }
 
   public Schema getAnySchema() {
@@ -190,6 +194,11 @@ public class Generator {
         return value;
       }
       case "string": {
+        Optional<String> formattedString = generators.get(schema.getFormat(), random);
+        if (formattedString.isPresent()) {
+          return formattedString.get();
+        }
+
         String pattern0 = FORMAT_REGEXES.get(schema.getFormat());
         if (pattern0 != null) {
           return patternReverser.reverse(pattern0, random);

--- a/src/main/java/net/jimblackler/jsongenerator/format/DateGenerator.java
+++ b/src/main/java/net/jimblackler/jsongenerator/format/DateGenerator.java
@@ -14,9 +14,6 @@ public class DateGenerator implements StringGenerator {
   private static final DateFormat FORMAT = new SimpleDateFormat("yyyy-MM-dd");
   private final long maxEpochMillis = Instant.now().getEpochSecond() * 1000 * 2;
 
-  public DateGenerator() {
-  }
-
   @Override
   public String get(Random random) {
     final long randomEpochMillis = (long) (random.nextDouble() * maxEpochMillis);

--- a/src/main/java/net/jimblackler/jsongenerator/format/DateGenerator.java
+++ b/src/main/java/net/jimblackler/jsongenerator/format/DateGenerator.java
@@ -1,0 +1,26 @@
+package net.jimblackler.jsongenerator.format;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Random;
+
+/**
+ * Generate a random ISO date from 1970 to the future.
+ */
+public class DateGenerator implements StringGenerator {
+
+  private static final DateFormat FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+  private final long maxEpochMillis = Instant.now().getEpochSecond() * 1000 * 2;
+
+  public DateGenerator() {
+  }
+
+  @Override
+  public String get(Random random) {
+    final long randomEpochMillis = (long) (random.nextDouble() * maxEpochMillis);
+    return FORMAT.format(Date.from(Instant.ofEpochMilli(randomEpochMillis)));
+  }
+
+}

--- a/src/main/java/net/jimblackler/jsongenerator/format/DateTimeGenerator.java
+++ b/src/main/java/net/jimblackler/jsongenerator/format/DateTimeGenerator.java
@@ -1,0 +1,27 @@
+package net.jimblackler.jsongenerator.format;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Random;
+
+/**
+ * Generate a random UTC date time from 1970 to the future.
+ */
+public class DateTimeGenerator implements StringGenerator {
+
+  private static final DateFormat FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+  private final long maxEpochMillis = Instant.now().getEpochSecond() * 1000 * 2;
+
+  public DateTimeGenerator() {
+  }
+
+  @Override
+  public String get(Random random) {
+    final long randomEpochMillis = (long) (random.nextDouble() * maxEpochMillis);
+    // append Z manually to mark the time as UTC
+    return FORMAT.format(Date.from(Instant.ofEpochMilli(randomEpochMillis))) + "Z";
+  }
+
+}

--- a/src/main/java/net/jimblackler/jsongenerator/format/DateTimeGenerator.java
+++ b/src/main/java/net/jimblackler/jsongenerator/format/DateTimeGenerator.java
@@ -14,9 +14,6 @@ public class DateTimeGenerator implements StringGenerator {
   private static final DateFormat FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
   private final long maxEpochMillis = Instant.now().getEpochSecond() * 1000 * 2;
 
-  public DateTimeGenerator() {
-  }
-
   @Override
   public String get(Random random) {
     final long randomEpochMillis = (long) (random.nextDouble() * maxEpochMillis);

--- a/src/main/java/net/jimblackler/jsongenerator/format/FormattedStringGenerators.java
+++ b/src/main/java/net/jimblackler/jsongenerator/format/FormattedStringGenerators.java
@@ -1,0 +1,27 @@
+package net.jimblackler.jsongenerator.format;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+
+public class FormattedStringGenerators {
+
+  private final Map<String, StringGenerator> generators;
+
+  public FormattedStringGenerators() {
+    this.generators = new HashMap<String, StringGenerator>() {{
+      put("date", new DateGenerator());
+      put("time", new TimeGenerator());
+      put("date-time", new DateTimeGenerator());
+    }};
+  }
+
+  public Optional<String> get(String format, Random random) {
+    if (format == null || !generators.containsKey(format)) {
+      return Optional.empty();
+    }
+    return Optional.of(generators.get(format).get(random));
+  }
+
+}

--- a/src/main/java/net/jimblackler/jsongenerator/format/StringGenerator.java
+++ b/src/main/java/net/jimblackler/jsongenerator/format/StringGenerator.java
@@ -1,0 +1,12 @@
+package net.jimblackler.jsongenerator.format;
+
+import java.util.Random;
+
+public interface StringGenerator {
+
+  /**
+   * @return random string with the given random generator.
+   */
+  String get(Random random);
+
+}

--- a/src/main/java/net/jimblackler/jsongenerator/format/TimeGenerator.java
+++ b/src/main/java/net/jimblackler/jsongenerator/format/TimeGenerator.java
@@ -12,10 +12,6 @@ public class TimeGenerator implements StringGenerator {
 
   private static final DateTimeFormatter FORMAT = new DateTimeFormatterBuilder().appendPattern("HH:mm:ss.SSS").toFormatter();
 
-  protected TimeGenerator() {
-
-  }
-
   @Override
   public String get(Random random) {
     // append Z manually to mark the time as UTC

--- a/src/main/java/net/jimblackler/jsongenerator/format/TimeGenerator.java
+++ b/src/main/java/net/jimblackler/jsongenerator/format/TimeGenerator.java
@@ -1,0 +1,25 @@
+package net.jimblackler.jsongenerator.format;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Random;
+
+/**
+ * Generate a random UTC time.
+ */
+public class TimeGenerator implements StringGenerator {
+
+  private static final DateTimeFormatter FORMAT = new DateTimeFormatterBuilder().appendPattern("HH:mm:ss.SSS").toFormatter();
+
+  protected TimeGenerator() {
+
+  }
+
+  @Override
+  public String get(Random random) {
+    // append Z manually to mark the time as UTC
+    return LocalTime.MIDNIGHT.plusSeconds(random.nextLong()).format(FORMAT) + "Z";
+  }
+
+}

--- a/src/test/java/net/jimblackler/jsongenerator/FakeSchemaTest.java
+++ b/src/test/java/net/jimblackler/jsongenerator/FakeSchemaTest.java
@@ -51,6 +51,16 @@ public class FakeSchemaTest {
           }
 
           @Override
+          public boolean isGenerateAdditionalProperties() {
+            return false;
+          }
+
+          @Override
+          public boolean useRomanCharsOnly() {
+            return false;
+          }
+
+          @Override
           public float nonRequiredPropertyChance() {
             return 0.5f;
           }

--- a/src/test/java/net/jimblackler/jsongenerator/FromInternet.java
+++ b/src/test/java/net/jimblackler/jsongenerator/FromInternet.java
@@ -61,6 +61,16 @@ public class FromInternet {
             }
 
             @Override
+            public boolean isGenerateAdditionalProperties() {
+              return false;
+            }
+
+            @Override
+            public boolean useRomanCharsOnly() {
+              return false;
+            }
+
+            @Override
             public float nonRequiredPropertyChance() {
               return 0.5f;
             }

--- a/src/test/java/net/jimblackler/jsongenerator/SchemaStoreTest.java
+++ b/src/test/java/net/jimblackler/jsongenerator/SchemaStoreTest.java
@@ -65,6 +65,16 @@ public class SchemaStoreTest {
             }
 
             @Override
+            public boolean isGenerateAdditionalProperties() {
+              return false;
+            }
+
+            @Override
+            public boolean useRomanCharsOnly() {
+              return false;
+            }
+
+            @Override
             public float nonRequiredPropertyChance() {
               return 0.5f;
             }

--- a/src/test/java/net/jimblackler/jsongenerator/SuiteTest.java
+++ b/src/test/java/net/jimblackler/jsongenerator/SuiteTest.java
@@ -100,6 +100,16 @@ public class SuiteTest {
                       }
 
                       @Override
+                      public boolean isGenerateAdditionalProperties() {
+                        return false;
+                      }
+
+                      @Override
+                      public boolean useRomanCharsOnly() {
+                        return false;
+                      }
+
+                      @Override
                       public float nonRequiredPropertyChance() {
                         return 0.5f;
                       }

--- a/src/test/java/net/jimblackler/jsongenerator/Test.java
+++ b/src/test/java/net/jimblackler/jsongenerator/Test.java
@@ -48,6 +48,16 @@ public class Test {
       }
 
       @Override
+      public boolean isGenerateAdditionalProperties() {
+        return false;
+      }
+
+      @Override
+      public boolean useRomanCharsOnly() {
+        return false;
+      }
+
+      @Override
       public float nonRequiredPropertyChance() {
         return 0.5f;
       }

--- a/src/test/java/net/jimblackler/jsongenerator/format/DateGeneratorTest.java
+++ b/src/test/java/net/jimblackler/jsongenerator/format/DateGeneratorTest.java
@@ -1,0 +1,20 @@
+package net.jimblackler.jsongenerator.format;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.jupiter.api.Test;
+
+class DateGeneratorTest {
+
+  private static final DateGenerator DATE_GENERATOR = new DateGenerator();
+  private static final ThreadLocalRandom RANDOM = ThreadLocalRandom.current();
+
+  @Test
+  public void test() {
+    assertNotNull(DateTimeFormatter.ISO_DATE.parse(DATE_GENERATOR.get(RANDOM)));
+    assertNotNull(DateTimeFormatter.ISO_LOCAL_DATE.parse(DATE_GENERATOR.get(RANDOM)));
+  }
+
+}

--- a/src/test/java/net/jimblackler/jsongenerator/format/DateTimeGeneratorTest.java
+++ b/src/test/java/net/jimblackler/jsongenerator/format/DateTimeGeneratorTest.java
@@ -1,0 +1,20 @@
+package net.jimblackler.jsongenerator.format;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.jupiter.api.Test;
+
+class DateTimeGeneratorTest {
+
+  private static final DateTimeGenerator DATE_TIME_GENERATOR = new DateTimeGenerator();
+  private static final ThreadLocalRandom RANDOM = ThreadLocalRandom.current();
+
+  @Test
+  public void test() {
+    assertNotNull(DateTimeFormatter.ISO_DATE_TIME.parse(DATE_TIME_GENERATOR.get(RANDOM)));
+    assertNotNull(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(DATE_TIME_GENERATOR.get(RANDOM)));
+  }
+
+}

--- a/src/test/java/net/jimblackler/jsongenerator/format/TimeGeneratorTest.java
+++ b/src/test/java/net/jimblackler/jsongenerator/format/TimeGeneratorTest.java
@@ -1,0 +1,20 @@
+package net.jimblackler.jsongenerator.format;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.jupiter.api.Test;
+
+class TimeGeneratorTest {
+
+  private static final TimeGenerator TIME_GENERATOR = new TimeGenerator();
+  private static final ThreadLocalRandom RANDOM = ThreadLocalRandom.current();
+
+  @Test
+  public void test() {
+    assertNotNull(DateTimeFormatter.ISO_TIME.parse(TIME_GENERATOR.get(RANDOM)));
+    assertNotNull(DateTimeFormatter.ISO_OFFSET_TIME.parse(TIME_GENERATOR.get(RANDOM)));
+  }
+
+}


### PR DESCRIPTION
## Summary

For string fields with a `format`, currently the generator uses a JavaScript engine to generate random strings based on preset regex. The strings will be validated by the `Fixer, and regenerated if they are not valid. This process is inefficient, as it sometimes takes tens or hundreds of attempts to generate a valid Json object.

In this PR, I'd like to introduce a set of string generator classes that can create random strings following the `format` with certainty. Currently three formats are supported: `date`, `time`, and `date-time`. I imagine that eventually we can have one generator for each format, and completely remove the JavaScript dependency.
